### PR TITLE
tvOS Minimal compatibility

### DIFF
--- a/Pod/Classes/DZProgressIndicatorSlider.h
+++ b/Pod/Classes/DZProgressIndicatorSlider.h
@@ -8,7 +8,14 @@
 
 #import <UIKit/UIKit.h>
 
+#if TARGET_OS_TV
+@interface DZProgressIndicatorSlider : UIProgressView
+-(void)setValue:(float)value;
+-(void)setValue:(float)value animated:(BOOL)animated;
+-(float)value;
+#else
 @interface DZProgressIndicatorSlider : UISlider
+#endif
 
 @property (weak, nonatomic) IBOutlet UIProgressView *progressView;
 

--- a/Pod/Classes/DZProgressIndicatorSlider.m
+++ b/Pod/Classes/DZProgressIndicatorSlider.m
@@ -36,7 +36,12 @@
 }
 
 - (void)commonInit {
+#if !TARGET_OS_TV
     [self setMaximumTrackTintColor:[UIColor clearColor]];
+#else
+    [self setBackgroundColor:[UIColor clearColor]];
+    [[self layer] setCornerRadius:1.0];
+#endif
     
     [[self.progressView layer] setCornerRadius:1.0f];
     
@@ -44,6 +49,18 @@
     [[self tintColor] getHue:&hue saturation:&sat brightness:&bri alpha:nil];
     [self.progressView setTintColor:[UIColor colorWithHue:hue saturation:(sat * 0.6f) brightness:bri alpha:1]];
 }
+
+#if TARGET_OS_TV
+- (void)setValue:(float)value {
+    [self setProgress:value];
+}
+- (void)setValue:(float)value animated:(BOOL)animated {
+    [self setProgress:value animated:animated];
+}
+- (float)value {
+    return [self progress];
+}
+#endif
 
 - (void)setTintColor:(UIColor *)tintColor {
     [super setTintColor:tintColor];

--- a/Pod/Classes/DZVideoPlayerViewController.h
+++ b/Pod/Classes/DZVideoPlayerViewController.h
@@ -72,7 +72,7 @@
 
 - (void)toggleFullscreen:(id)sender;
 
-- (void)seek:(UISlider *)slider;
+- (void)seek:(DZProgressIndicatorSlider *)slider;
 
 - (void)seekToTime:(NSTimeInterval)newPlaybackTime;
 

--- a/Pod/Classes/DZVideoPlayerViewController.m
+++ b/Pod/Classes/DZVideoPlayerViewController.m
@@ -359,7 +359,7 @@ static const NSString *PlayerStatusContext;
     [self startIdleCountdown];
 }
 
-- (void)seek:(UISlider *)slider {
+- (void)seek:(DZProgressIndicatorSlider *)slider {
     if( self.playerItem != nil ) {
         int timescale = self.playerItem.asset.duration.timescale;
         if( timescale > 0 ) {
@@ -612,9 +612,11 @@ static const NSString *PlayerStatusContext;
     [self.fullscreenShrinkButton addTarget:self action:@selector(toggleFullscreen:) forControlEvents:UIControlEventTouchUpInside];
     [self.fullscreenExpandButton addTarget:self action:@selector(toggleFullscreen:) forControlEvents:UIControlEventTouchUpInside];
     
+#if !TARGET_OS_TV
     [self.progressIndicator addTarget:self action:@selector(seek:) forControlEvents:UIControlEventValueChanged];
     [self.progressIndicator addTarget:self action:@selector(startSeeking:) forControlEvents:UIControlEventTouchDown];
     [self.progressIndicator addTarget:self action:@selector(endSeeking:) forControlEvents:UIControlEventTouchUpInside|UIControlEventTouchUpOutside];
+#endif
     
     [self.doneButton addTarget:self action:@selector(onDoneButtonTouched) forControlEvents:UIControlEventTouchUpInside];
 }


### PR DESCRIPTION
Since I started working on tvOS and still using DZVideoPlayerViewController, I wanted to be able to continue to use it as I was before. That is why I choose to change only the super class of DZProgressIndicatorSlider on tvOS. Everything can be improved but this provides a compatibility solution at least. I hope the DZVideoPlayerViewController will support tvOS interaction eventually. AS long as I would work on tvOS, I guess I will have to do it anyway. If I can make it good, I will commit and create an other pull request with improvements.
